### PR TITLE
Escape \ in filter

### DIFF
--- a/compiled-commands/filter.js
+++ b/compiled-commands/filter.js
@@ -15,6 +15,7 @@
           if ((mask != null ? mask : "") === "") {
             return (input != null ? input : "") === "" ? null : input;
           }
+          mask = mask.replace(/\\/g, '\\\\');
           if (input.match(mask)) {
             return input.split(mask).join(mask.yellow);
           } else {


### PR DESCRIPTION
To make it possible to filter based on environment vars paths in Windows, e.g %cd%
PS: Sorry, I don't know any LiveScript and although it seems obvious I didn't want to propose changes blindly.
