### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Joyable equivalents for existent linux commands
 
 npm install -g nixar
 
-###Commands
+### Commands
 
 #### after
 Prints everything after [mask]. Has option 'after last [mask]'


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
